### PR TITLE
Fix replacing links to anchors in the same page.

### DIFF
--- a/plugin.coffee
+++ b/plugin.coffee
@@ -57,7 +57,7 @@ module.exports = (wintersmith, callback) ->
       @_html = @_html.replace(/(<(a|img)[^>]+(href|src)=")(?!http|\/)([^"]+)/g, '$1' + loc + '$4')
       # handles non-relative links within the site (e.g. /about)
       if base
-        @_html = @_html.replace(/(<(a|img)[^>]+(href|src)=")\/(?!\#)([^"]+)/g, '$1' + base + '/$4')
+        @_html = @_html.replace(/(<(a|img)[^>]+(href|src)=")\/([^"]+)/g, '$1' + base + '/$4')
       return @_html
     
     getIntro: (base) ->


### PR DESCRIPTION
The regexps that replace links weren't taking into account links to other anchors on the page, which just look like `#idOfAnchor`. They were changed into `/path/to/dir/#idOfAnchor` instead of `/path/to/dir/page.html#idOfAnchor`. This change just adds the filename in there. (Sorry for all the commits, got a bit messy)
