### PR TITLE
bugfix: avoid double `//` in links

### DIFF
--- a/plugin.coffee
+++ b/plugin.coffee
@@ -34,8 +34,8 @@ module.exports = (env, callback) ->
       @_html = @_html.replace(/(<(a|img)[^>]+(href|src)=")(?!http|\/)([^"]+)/g, '$1' + loc + '$4')
       # handles non-relative links within the site (e.g. /about)
       if base
-        # avoid double '//' entries: remove base if it is equal to '/'
-        base_adj = if base == '/' then '' else base
+        # avoid double '//' entries: remove all tailing '/'-es
+        base_adj = base.replace(/[\/]+$/,'')
         # adjust non-relative links so they use this site's base
         @_html = @_html.replace(/(<(a|img)[^>]+(href|src)=")\/([^"]+)/g, '$1' + base_adj + '/$4')
       return @_html


### PR DESCRIPTION
When the base url contains a tailing `/` (e.g. your blog is hosted at the root of your page, then base is `/`), then the current replacement for non-relative links leads to creating double-`//` links, e.g.: `http://localhost:8080//articles/mine/image.jpeg`. This will lead the browser to look into `http://articles/mine/image.jpeg` instead of `http://localhost:8080/articles/mine/image.jpeg` (tested in Chrome and Firefox). Double-`//` also cause problems at other positions in the link (e.g. `http://localhost:8080/base//articles/mine/image.jpeg`; although some webservers may prevent this).
