### PR TITLE
bugfix: pandoc error message was lost and generator failed

### DIFF
--- a/plugin.coffee
+++ b/plugin.coffee
@@ -12,10 +12,7 @@ q = async.queue((page, callback) ->
 
 pandocRender = (page, callback) ->
   q.push page, (err, page) ->
-    if err
-      console.log err
-    else
-      callback null, page
+    callback err, page
       
 module.exports = (env, callback) ->
 


### PR DESCRIPTION
Template render error: TypeError: Cannot call method 'replace' of undefined
actually means that pandoc refused to create the document, but original pandoc's explanation was lost. Now it gets printed to console
