### PR TITLE
Update for Wintersmith 2.1

### DIFF
--- a/example/templates/index.jade
+++ b/example/templates/index.jade
@@ -1,11 +1,11 @@
-!!! 5
+doctype html
 html(lang='en')
   head
     meta(charset='utf-8')
     title= locals.title
     link(rel='stylesheet', href='style.css')
     link(rel='stylesheet', href='syntax.css')
-    script(src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML")
+    script(src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML")
   body
     h1= page.title
     != page.html

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-require('coffee-script');
+require('coffee-script/register');
 module.exports = require('./plugin');

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "wintersmith-pandoc",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "Luke Hagan <lukehagan.com>",
   "description": "pandoc plugin for wintersmith",
   "license": "MIT",
   "dependencies": {
-    "pdc": ">= 0.1.x",
-    "async": ">= 0.1.x",
-    "coffee-script": "1.2.x"
+    "pdc": "0.2.x",
+    "async": "0.9.x",
+    "coffee-script": "1.9.x"
   }
 }


### PR DESCRIPTION
Just a small maintenance update mainly for Wintersmith 2.1, CoffeeScript 1.9, and the new CDN URL for MathJax.
